### PR TITLE
Fix early class loading issues

### DIFF
--- a/src/main/java/de/pnku/mstv_mweaponv/mixin/mtoolv/MtoolvMixinPlugin.java
+++ b/src/main/java/de/pnku/mstv_mweaponv/mixin/mtoolv/MtoolvMixinPlugin.java
@@ -10,10 +10,10 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import java.util.List;
 import java.util.Set;
 
-import static de.pnku.mstv_mweaponv.MoreWeaponVariants.isMtoolvLoaded;
-
 public class MtoolvMixinPlugin implements IMixinConfigPlugin {
     public static final Logger LOGGER = LoggerFactory.getLogger("mweaponvmixinplugin");
+
+    private boolean isMtoolvLoaded;
 
     @Override
     public void onLoad(String mixinPackage) {


### PR DESCRIPTION
The mixin plugin references the `MoreWeaponVariants` class, which itself references classes in the `net.minecraft` package. Doing this causes Minecraft's classes to be loaded before initialization, which prevents mods from applying mixins.

Since the `MoreWeaponVariants` and `MtoolvMixinPlugin` class are both checking whether the mod is loaded, they don't need to access one another, and we can just copy the boolean into the mixin plugin and keep it private. My guess is this was caused by a simple typo, probably the IDE auto-suggesting something unhelpfully. 